### PR TITLE
ueaFactory new changes

### DIFF
--- a/src/Interfaces/IUEAFactory.sol
+++ b/src/Interfaces/IUEAFactory.sol
@@ -69,7 +69,7 @@ interface IUEAFactory {
      * @dev Returns the owner key (UOA) for a given UEA address
      * @param addr Any given address ( msg.sender ) on push chain
      * @return account The Universal Account information associated with this UEA
-     * @return isUEA True if the address is a native EOA, false if it's a UEA
+     * @return isUEA True if the address addr is a UEA contract. Else it is a native EOA of PUSH chain (i.e., isUEA = false)
      */
     function getOriginForUEA(address addr) external view returns (UniversalAccount memory account, bool isUEA);
 

--- a/src/Interfaces/IUEAFactory.sol
+++ b/src/Interfaces/IUEAFactory.sol
@@ -68,9 +68,10 @@ interface IUEAFactory {
     /**
      * @dev Returns the owner key (UOA) for a given UEA address
      * @param _uea The UEA address
-     * @return The owner key associated with this UEA
+     * @return account The Universal Account information associated with this UEA
+     * @return isNative True if the address is a native EOA, false if it's a UEA
      */
-    function getOriginForUEA(address _uea) external view returns (bytes memory);
+    function getOriginForUEA(address _uea) external view returns (UniversalAccount memory account, bool isNative);
 
     /**
      * @dev Returns the computed UEA address for a given Universal Account ID and deployment status

--- a/src/Interfaces/IUEAFactory.sol
+++ b/src/Interfaces/IUEAFactory.sol
@@ -67,11 +67,11 @@ interface IUEAFactory {
 
     /**
      * @dev Returns the owner key (UOA) for a given UEA address
-     * @param _uea The UEA address
+     * @param addr Any given address ( msg.sender ) on push chain
      * @return account The Universal Account information associated with this UEA
-     * @return isNative True if the address is a native EOA, false if it's a UEA
+     * @return isUEA True if the address is a native EOA, false if it's a UEA
      */
-    function getOriginForUEA(address _uea) external view returns (UniversalAccount memory account, bool isNative);
+    function getOriginForUEA(address addr) external view returns (UniversalAccount memory account, bool isUEA);
 
     /**
      * @dev Returns the computed UEA address for a given Universal Account ID and deployment status

--- a/src/UEAFactoryV1.sol
+++ b/src/UEAFactoryV1.sol
@@ -216,8 +216,8 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
     }
 
     /// @inheritdoc IUEAFactory
-    function getOriginForUEA(address _uea) external view returns (UniversalAccount memory account, bool isNative) {
-        account = UEA_to_UOA[_uea];
+    function getOriginForUEA(address addr) external view returns (UniversalAccount memory account, bool isNative) {
+        account = UEA_to_UOA[addr];
         
         // If the address has no associated Universal Account (owner.length == 0), 
         // then it's likely a native EOA account on PUSH Chain

--- a/src/UEAFactoryV1.sol
+++ b/src/UEAFactoryV1.sol
@@ -224,9 +224,6 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
         if (account.owner.length == 0) {
             isNative = true;
             // We don't need to set any values for native accounts
-        } else {
-            // This is a UEA with a valid Universal Account
-            isNative = false;
         }
         
         return (account, isNative);

--- a/src/UEAFactoryV1.sol
+++ b/src/UEAFactoryV1.sol
@@ -216,17 +216,17 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
     }
 
     /// @inheritdoc IUEAFactory
-    function getOriginForUEA(address addr) external view returns (UniversalAccount memory account, bool isNative) {
+    function getOriginForUEA(address addr) external view returns (UniversalAccount memory account, bool isUEA) {
         account = UEA_to_UOA[addr];
 
         // If the address has no associated Universal Account (owner.length == 0),
         // then it's likely a native EOA account on PUSH Chain
         if (account.owner.length == 0) {
-            isNative = true;
+            isUEA = true;
             // We don't need to set any values for native accounts
         }
 
-        return (account, isNative);
+        return (account, isUEA);
     }
 
     /// @inheritdoc IUEAFactory

--- a/src/UEAFactoryV1.sol
+++ b/src/UEAFactoryV1.sol
@@ -221,7 +221,7 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
 
         // If the address has no associated Universal Account (owner.length == 0),
         // then it's likely a native EOA account on PUSH Chain
-        if (account.owner.length == 0) {
+        if (account.owner.length > 0) {
             isUEA = true;
             // We don't need to set any values for native accounts
         }

--- a/src/UEAFactoryV1.sol
+++ b/src/UEAFactoryV1.sol
@@ -221,9 +221,9 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
 
         // If the address has no associated Universal Account (owner.length == 0),
         // then it's likely a native EOA account on PUSH Chain
+        // else it is a UEA contract
         if (account.owner.length > 0) {
             isUEA = true;
-            // We don't need to set any values for native accounts
         }
 
         return (account, isUEA);

--- a/src/UEAFactoryV1.sol
+++ b/src/UEAFactoryV1.sol
@@ -218,14 +218,14 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
     /// @inheritdoc IUEAFactory
     function getOriginForUEA(address addr) external view returns (UniversalAccount memory account, bool isNative) {
         account = UEA_to_UOA[addr];
-        
-        // If the address has no associated Universal Account (owner.length == 0), 
+
+        // If the address has no associated Universal Account (owner.length == 0),
         // then it's likely a native EOA account on PUSH Chain
         if (account.owner.length == 0) {
             isNative = true;
             // We don't need to set any values for native accounts
         }
-        
+
         return (account, isNative);
     }
 

--- a/src/UEAFactoryV1.sol
+++ b/src/UEAFactoryV1.sol
@@ -42,8 +42,8 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
     /// @notice Maps UniversalAccount(hash) to their deployed UEA contract addresses
     mapping(bytes32 => address) public UOA_to_UEA;
 
-    /// @notice Maps UEA addresses to their owner keys
-    mapping(address => bytes) private UEA_to_UOA;
+    /// @notice Maps UEA addresses to their Universal Account information
+    mapping(address => UniversalAccount) private UEA_to_UOA;
 
     /// @notice Maps chain identifiers to their registered VM type hashes
     mapping(bytes32 => bytes32) public CHAIN_to_VM;
@@ -172,7 +172,7 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
 
         address _UEA = _ueaImplementation.cloneDeterministic(salt);
         UOA_to_UEA[salt] = _UEA;
-        UEA_to_UOA[_UEA] = _id.owner; // Store the inverse mapping
+        UEA_to_UOA[_UEA] = _id; // Store the inverse mapping
         IUEA(_UEA).initialize(_id);
 
         emit UEADeployed(_UEA, _id.owner, chainHash);
@@ -215,21 +215,24 @@ contract UEAFactoryV1 is Initializable, OwnableUpgradeable, IUEAFactory {
         return size > 0;
     }
 
-    /**
-     * @dev Returns the UOA (owner key) for a given UEA address
-     * @param _uea The UEA address
-     * @return The owner key (UOA) associated with this UEA
-     */
-    function getOriginForUEA(address _uea) external view returns (bytes memory) {
-        return UEA_to_UOA[_uea];
+    /// @inheritdoc IUEAFactory
+    function getOriginForUEA(address _uea) external view returns (UniversalAccount memory account, bool isNative) {
+        account = UEA_to_UOA[_uea];
+        
+        // If the address has no associated Universal Account (owner.length == 0), 
+        // then it's likely a native EOA account on PUSH Chain
+        if (account.owner.length == 0) {
+            isNative = true;
+            // We don't need to set any values for native accounts
+        } else {
+            // This is a UEA with a valid Universal Account
+            isNative = false;
+        }
+        
+        return (account, isNative);
     }
 
-    /**
-     * @dev Returns the computed UEA address for a given Universal Account ID and deployment status
-     * @param _id The Universal Account information
-     * @return uea The address of the UEA (computed deterministically)
-     * @return isDeployed True if the UEA has already been deployed
-     */
+    /// @inheritdoc IUEAFactory
     function getUEAForOrigin(UniversalAccount memory _id) external view returns (address uea, bool isDeployed) {
         // Generate salt from the UniversalAccount struct
         bytes32 salt = generateSalt(_id);

--- a/test/UEAFactory.t.sol
+++ b/test/UEAFactory.t.sol
@@ -194,7 +194,10 @@ contract UEAFactoryTest is Test {
         assertTrue(factory.hasCode(ueaAddress));
 
         // Check the owner
-        assertEq(factory.getOriginForUEA(ueaAddress), ownerBytes);
+        (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+        assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(_id.chain)));
+        assertEq(keccak256(retrievedAccount.owner), keccak256(_id.owner));
+        assertFalse(isNative);
     }
 
     function testRevertWhenDeployingUEAForUnregisteredChain() public {
@@ -304,7 +307,10 @@ contract UEAFactoryTest is Test {
 
             address ueaAddress = factory.deployUEA(_id);
             assertTrue(factory.hasCode(ueaAddress));
-            assertEq(factory.getOriginForUEA(ueaAddress), ownerBytes);
+            
+            (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+            assertEq(keccak256(retrievedAccount.owner), keccak256(ownerBytes));
+            assertFalse(isNative);
         }
     }
 
@@ -321,12 +327,18 @@ contract UEAFactoryTest is Test {
         UniversalAccount memory newAccount = UniversalAccount({chain: "ETHEREUM", owner: newOwnerBytes});
 
         // The owner mapping can't be changed - a new UEA would need to be deployed
-        assertEq(factory.getOriginForUEA(ueaAddress), ownerBytes);
+        (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+        assertEq(keccak256(retrievedAccount.owner), keccak256(ownerBytes));
+        assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(_id.chain)));
+        assertFalse(isNative);
 
         // Deploy UEA for new owner - this should be a different address
         address newUEAAddress = factory.deployUEA(newAccount);
         assertNotEq(ueaAddress, newUEAAddress);
-        assertEq(factory.getOriginForUEA(newUEAAddress), newOwnerBytes);
+        (UniversalAccount memory newRetrievedAccount, bool isNewNative) = factory.getOriginForUEA(newUEAAddress);
+        assertEq(keccak256(newRetrievedAccount.owner), keccak256(newOwnerBytes));
+        assertEq(keccak256(abi.encode(newRetrievedAccount.chain)), keccak256(abi.encode(newAccount.chain)));
+        assertFalse(isNewNative);
     }
 
     function testOwnershipFunctions() public {
@@ -480,7 +492,10 @@ contract UEAFactoryTest is Test {
 
             // Verify mappings are consistent
             assertEq(factory.UOA_to_UEA(salt), deployedUEAs[i]);
-            assertEq(factory.getOriginForUEA(deployedUEAs[i]), ownerValues[i]);
+            (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(deployedUEAs[i]);
+            assertEq(keccak256(retrievedAccount.owner), keccak256(ownerValues[i]));
+            assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(chain)));
+            assertFalse(isNative);
         }
 
         // Verify all deployed accounts are retrievable
@@ -536,8 +551,10 @@ contract UEAFactoryTest is Test {
         address ueaAddress = factory.deployUEA(account);
 
         // Test getOriginForUEA
-        bytes memory retrievedOwner = factory.getOriginForUEA(ueaAddress);
-        assertEq(keccak256(retrievedOwner), keccak256(ownerBytes));
+        (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+        assertEq(keccak256(retrievedAccount.owner), keccak256(ownerBytes));
+        assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(account.chain)));
+        assertFalse(isNative);
 
         // Test getUEAForOrigin
         (address retrievedUEA, bool isDeployed) = factory.getUEAForOrigin(account);
@@ -546,8 +563,10 @@ contract UEAFactoryTest is Test {
 
         // Test with non-existent UEA
         address randomAddr = makeAddr("random");
-        bytes memory emptyOwner = factory.getOriginForUEA(randomAddr);
-        assertEq(emptyOwner.length, 0);
+        (UniversalAccount memory randomAccount, bool isRandomNative) = factory.getOriginForUEA(randomAddr);
+        assertTrue(isRandomNative);
+        assertEq(randomAccount.owner.length, 0);
+        assertEq(bytes(randomAccount.chain).length, 0);
 
         // Test with non-existent owner key but predictable address
         (address newOwner, uint256 newOwnerPK) = makeAddrAndKey("newOwner");
@@ -595,7 +614,51 @@ contract UEAFactoryTest is Test {
         assertTrue(uea1 != uea2);
 
         // Verify the owner keys are mapped correctly
-        assertEq(keccak256(factory.getOriginForUEA(uea1)), keccak256(owner1Key));
-        assertEq(keccak256(factory.getOriginForUEA(uea2)), keccak256(owner2Key));
+        (UniversalAccount memory retrievedAccount1, bool isNative1) = factory.getOriginForUEA(uea1);
+        (UniversalAccount memory retrievedAccount2, bool isNative2) = factory.getOriginForUEA(uea2);
+        
+        assertEq(keccak256(retrievedAccount1.owner), keccak256(owner1Key));
+        assertEq(keccak256(retrievedAccount2.owner), keccak256(owner2Key));
+        assertFalse(isNative1);
+        assertFalse(isNative2);
+    }
+
+    // Test for native account detection with empty owner and chain
+    function testNativeAccountDetection() public {
+        // Create a random address that is not a UEA
+        address randomAddr = makeAddr("randomNative");
+        
+        // Check if it's correctly identified as a native account
+        (UniversalAccount memory account, bool isNative) = factory.getOriginForUEA(randomAddr);
+        
+        assertTrue(isNative);
+        // For native accounts, both owner and chain should be empty
+        assertEq(account.owner.length, 0);
+        assertEq(bytes(account.chain).length, 0);
+    }
+    
+    // Test for comparing native and UEA accounts
+    function testCompareNativeAndUEAAccounts() public {
+        // Create and deploy a UEA
+        bytes memory ownerBytes = abi.encodePacked(makeAddr("uea_owner"));
+        UniversalAccount memory uea_id = UniversalAccount({chain: "ETHEREUM", owner: ownerBytes});
+        address ueaAddress = factory.deployUEA(uea_id);
+        
+        // Create a random native address
+        address nativeAddr = makeAddr("native_user");
+        
+        // Get account info for both
+        (UniversalAccount memory ueaAccount, bool isUeaNative) = factory.getOriginForUEA(ueaAddress);
+        (UniversalAccount memory nativeAccount, bool isNative) = factory.getOriginForUEA(nativeAddr);
+        
+        // UEA should have proper data and not be native
+        assertFalse(isUeaNative);
+        assertEq(keccak256(ueaAccount.owner), keccak256(ownerBytes));
+        assertEq(keccak256(abi.encode(ueaAccount.chain)), keccak256(abi.encode("ETHEREUM")));
+        
+        // Native account should be marked as native and have empty data
+        assertTrue(isNative);
+        assertEq(nativeAccount.owner.length, 0);
+        assertEq(bytes(nativeAccount.chain).length, 0);
     }
 }

--- a/test/UEAFactory.t.sol
+++ b/test/UEAFactory.t.sol
@@ -194,10 +194,10 @@ contract UEAFactoryTest is Test {
         assertTrue(factory.hasCode(ueaAddress));
 
         // Check the owner
-        (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+        (UniversalAccount memory retrievedAccount, bool isUEA) = factory.getOriginForUEA(ueaAddress);
         assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(_id.chain)));
         assertEq(keccak256(retrievedAccount.owner), keccak256(_id.owner));
-        assertFalse(isNative);
+        assertFalse(isUEA);
     }
 
     function testRevertWhenDeployingUEAForUnregisteredChain() public {
@@ -308,9 +308,9 @@ contract UEAFactoryTest is Test {
             address ueaAddress = factory.deployUEA(_id);
             assertTrue(factory.hasCode(ueaAddress));
 
-            (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+            (UniversalAccount memory retrievedAccount, bool isUEA) = factory.getOriginForUEA(ueaAddress);
             assertEq(keccak256(retrievedAccount.owner), keccak256(ownerBytes));
-            assertFalse(isNative);
+            assertFalse(isUEA);
         }
     }
 
@@ -327,10 +327,10 @@ contract UEAFactoryTest is Test {
         UniversalAccount memory newAccount = UniversalAccount({chain: "ETHEREUM", owner: newOwnerBytes});
 
         // The owner mapping can't be changed - a new UEA would need to be deployed
-        (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+        (UniversalAccount memory retrievedAccount, bool isUEA) = factory.getOriginForUEA(ueaAddress);
         assertEq(keccak256(retrievedAccount.owner), keccak256(ownerBytes));
         assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(_id.chain)));
-        assertFalse(isNative);
+        assertFalse(isUEA);
 
         // Deploy UEA for new owner - this should be a different address
         address newUEAAddress = factory.deployUEA(newAccount);
@@ -492,10 +492,10 @@ contract UEAFactoryTest is Test {
 
             // Verify mappings are consistent
             assertEq(factory.UOA_to_UEA(salt), deployedUEAs[i]);
-            (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(deployedUEAs[i]);
+            (UniversalAccount memory retrievedAccount, bool isUEA) = factory.getOriginForUEA(deployedUEAs[i]);
             assertEq(keccak256(retrievedAccount.owner), keccak256(ownerValues[i]));
             assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(chain)));
-            assertFalse(isNative);
+            assertFalse(isUEA);
         }
 
         // Verify all deployed accounts are retrievable
@@ -551,10 +551,10 @@ contract UEAFactoryTest is Test {
         address ueaAddress = factory.deployUEA(account);
 
         // Test getOriginForUEA
-        (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
+        (UniversalAccount memory retrievedAccount, bool isUEA) = factory.getOriginForUEA(ueaAddress);
         assertEq(keccak256(retrievedAccount.owner), keccak256(ownerBytes));
         assertEq(keccak256(abi.encode(retrievedAccount.chain)), keccak256(abi.encode(account.chain)));
-        assertFalse(isNative);
+        assertFalse(isUEA);
 
         // Test getUEAForOrigin
         (address retrievedUEA, bool isDeployed) = factory.getUEAForOrigin(account);
@@ -614,13 +614,13 @@ contract UEAFactoryTest is Test {
         assertTrue(uea1 != uea2);
 
         // Verify the owner keys are mapped correctly
-        (UniversalAccount memory retrievedAccount1, bool isNative1) = factory.getOriginForUEA(uea1);
-        (UniversalAccount memory retrievedAccount2, bool isNative2) = factory.getOriginForUEA(uea2);
+        (UniversalAccount memory retrievedAccount1, bool isUEA1) = factory.getOriginForUEA(uea1);
+        (UniversalAccount memory retrievedAccount2, bool isUEA2) = factory.getOriginForUEA(uea2);
 
         assertEq(keccak256(retrievedAccount1.owner), keccak256(owner1Key));
         assertEq(keccak256(retrievedAccount2.owner), keccak256(owner2Key));
-        assertFalse(isNative1);
-        assertFalse(isNative2);
+        assertFalse(isUEA1);
+        assertFalse(isUEA2);
     }
 
     // Test for native account detection with empty owner and chain
@@ -629,9 +629,9 @@ contract UEAFactoryTest is Test {
         address randomAddr = makeAddr("randomNative");
 
         // Check if it's correctly identified as a native account
-        (UniversalAccount memory account, bool isNative) = factory.getOriginForUEA(randomAddr);
+        (UniversalAccount memory account, bool isUEA) = factory.getOriginForUEA(randomAddr);
 
-        assertTrue(isNative);
+        assertTrue(isUEA);
         // For native accounts, both owner and chain should be empty
         assertEq(account.owner.length, 0);
         assertEq(bytes(account.chain).length, 0);
@@ -649,7 +649,7 @@ contract UEAFactoryTest is Test {
 
         // Get account info for both
         (UniversalAccount memory ueaAccount, bool isUeaNative) = factory.getOriginForUEA(ueaAddress);
-        (UniversalAccount memory nativeAccount, bool isNative) = factory.getOriginForUEA(nativeAddr);
+        (UniversalAccount memory nativeAccount, bool isUEA) = factory.getOriginForUEA(nativeAddr);
 
         // UEA should have proper data and not be native
         assertFalse(isUeaNative);
@@ -657,7 +657,7 @@ contract UEAFactoryTest is Test {
         assertEq(keccak256(abi.encode(ueaAccount.chain)), keccak256(abi.encode("ETHEREUM")));
 
         // Native account should be marked as native and have empty data
-        assertTrue(isNative);
+        assertTrue(isUEA);
         assertEq(nativeAccount.owner.length, 0);
         assertEq(bytes(nativeAccount.chain).length, 0);
     }

--- a/test/UEAFactory.t.sol
+++ b/test/UEAFactory.t.sol
@@ -307,7 +307,7 @@ contract UEAFactoryTest is Test {
 
             address ueaAddress = factory.deployUEA(_id);
             assertTrue(factory.hasCode(ueaAddress));
-            
+
             (UniversalAccount memory retrievedAccount, bool isNative) = factory.getOriginForUEA(ueaAddress);
             assertEq(keccak256(retrievedAccount.owner), keccak256(ownerBytes));
             assertFalse(isNative);
@@ -616,7 +616,7 @@ contract UEAFactoryTest is Test {
         // Verify the owner keys are mapped correctly
         (UniversalAccount memory retrievedAccount1, bool isNative1) = factory.getOriginForUEA(uea1);
         (UniversalAccount memory retrievedAccount2, bool isNative2) = factory.getOriginForUEA(uea2);
-        
+
         assertEq(keccak256(retrievedAccount1.owner), keccak256(owner1Key));
         assertEq(keccak256(retrievedAccount2.owner), keccak256(owner2Key));
         assertFalse(isNative1);
@@ -627,35 +627,35 @@ contract UEAFactoryTest is Test {
     function testNativeAccountDetection() public {
         // Create a random address that is not a UEA
         address randomAddr = makeAddr("randomNative");
-        
+
         // Check if it's correctly identified as a native account
         (UniversalAccount memory account, bool isNative) = factory.getOriginForUEA(randomAddr);
-        
+
         assertTrue(isNative);
         // For native accounts, both owner and chain should be empty
         assertEq(account.owner.length, 0);
         assertEq(bytes(account.chain).length, 0);
     }
-    
+
     // Test for comparing native and UEA accounts
     function testCompareNativeAndUEAAccounts() public {
         // Create and deploy a UEA
         bytes memory ownerBytes = abi.encodePacked(makeAddr("uea_owner"));
         UniversalAccount memory uea_id = UniversalAccount({chain: "ETHEREUM", owner: ownerBytes});
         address ueaAddress = factory.deployUEA(uea_id);
-        
+
         // Create a random native address
         address nativeAddr = makeAddr("native_user");
-        
+
         // Get account info for both
         (UniversalAccount memory ueaAccount, bool isUeaNative) = factory.getOriginForUEA(ueaAddress);
         (UniversalAccount memory nativeAccount, bool isNative) = factory.getOriginForUEA(nativeAddr);
-        
+
         // UEA should have proper data and not be native
         assertFalse(isUeaNative);
         assertEq(keccak256(ueaAccount.owner), keccak256(ownerBytes));
         assertEq(keccak256(abi.encode(ueaAccount.chain)), keccak256(abi.encode("ETHEREUM")));
-        
+
         // Native account should be marked as native and have empty data
         assertTrue(isNative);
         assertEq(nativeAccount.owner.length, 0);


### PR DESCRIPTION
includes following changes:

-  `getOriginForUEA` now returns UniversalAccount and whether or not the passed addr argument is a native PUSH Chain address or a UEA.
- isNative return param returns true if addr passed as arg in `getOriginForUEA` is a native push chain EOA.
- test cases updated accordingly.