### PR TITLE
Add Protocol Fee Config, PC20/PC721 Chain-Support Mapping, Public Getters, Events, and Tests to UniversalGatewayPC + Adjust Storage Gap

### DIFF
--- a/src/Interfaces/IUniversalCore.sol
+++ b/src/Interfaces/IUniversalCore.sol
@@ -12,6 +12,9 @@ interface IUniversalCore {
     event SetGasToken(string chainId, address prc20);
     event SetDefaultDeadlineMins(uint256 minutesValue);
     event SetSupportedToken(address indexed prc20, bool supported);
+    event ProtocolFeesUpdated(uint256 pc20ProtocolFees, uint256 pc721ProtocolFees, uint256 defaultProtocolFees);
+    event SetPC20Support(string indexed chainNamespace, bool supported);
+    event SetPC721Support(string indexed chainNamespace, bool supported);
     event SetGasPCPool(string chainId, address pool, uint24 fee);   
     event DepositPRC20WithAutoSwap(address prc20, uint256 amountIn, address pcToken, uint256 amountOut, uint24 fee, address target);
     // =========================


### PR DESCRIPTION
UniversalGatewayPC.sol
- public getters added PC20_PROTOCOL_FEES, PC721_PROTOCOL_FEES, DEFAULT_PROTOCOL_FEES
- setter setProtocolFees added with onlyUEModule modifier
- event ProtocolFeesUpdated added
- added testcases
- added isPC20SupportedOnChain, isPC721SupportedOnChain mapping
- added functions setPC20SupportOnChain, setPC721SupportOnChain
- added testcases for the same
- changed gap to 45 since 3 uint and 2 mapping are added (at the bottom of the variables decleration)