### PR TITLE
CEA Single Call Fix + UVCore AutoSwap for Withdrawal

### DIFF
--- a/src/CEA/CEA.sol
+++ b/src/CEA/CEA.sol
@@ -97,25 +97,27 @@ contract CEA is ICEA, ReentrancyGuard {
     /// @notice         Executes a universal transaction.
     /// @dev            Payload can be either:
     ///                 - MULTICALL: payload starts with MULTICALL_SELECTOR + ABI-encoded Multicall[]
-    ///                 - SINGLE CALL: raw bytes data for a single call
+    ///                 - MIGRATION: payload starts with MIGRATION_SELECTOR
+    ///                 - SINGLE CALL: non-empty payload forwarded to recipient, or empty to park funds
     ///                 SDK is responsible for crafting correct payload format.
-    /// @param txId      Unique transaction identifier (must not be executed before)
+    /// @param txId             Unique transaction identifier (must not be executed before)
     /// @param universalTxId    Universal transaction identifier for cross-chain tracking
     /// @param originCaller     Address of the origin caller (must match pushAccount)
-    /// @param payload          Either multicall or single call payload
-    function executeUniversalTx(bytes32 txId, bytes32 universalTxId, address originCaller, bytes calldata payload)
-        external
-        payable
-        onlyVault
-        nonReentrant
-    {
-        // Top-level validation
+    /// @param recipient        Target contract for single-call execution. Ignored for multicall/migration payloads.
+    /// @param payload          Either multicall, migration, or single call payload
+    function executeUniversalTx(
+        bytes32 txId,
+        bytes32 universalTxId,
+        address originCaller,
+        address recipient,
+        bytes calldata payload
+    ) external payable onlyVault nonReentrant {
         if (isExecuted[txId]) revert CEAErrors.PayloadExecuted();
         if (originCaller != pushAccount) revert CEAErrors.InvalidUEA();
 
         isExecuted[txId] = true;
 
-        _handleExecution(txId, universalTxId, originCaller, payload);
+        _handleExecution(txId, universalTxId, originCaller, recipient, payload);
     }
 
     /// @notice         Sends funds (and optionally a payload) from CEA to its UEA on Push Chain.
@@ -157,17 +159,22 @@ contract CEA is ICEA, ReentrancyGuard {
     //========================
 
     /// @notice         Routes execution based on payload type (MULTICALL vs MIGRATION vs SINGLE CALL).
-    /// @dev            Three-way branch matching UEA_EVM pattern:
+    /// @dev            Three-way branch:
     ///                 1. isMulticall → decode + _handleMulticall
     ///                 2. isMigration → _handleMigration (top-level, no Multicall wrapper)
-    ///                 3. else → _handleSingleCall (backwards compatibility)
-    /// @param txId      Transaction identifier for event emission
+    ///                 3. else → _handleSingleCall (park funds or single external call)
+    /// @param txId             Transaction identifier for event emission
     /// @param universalTxId    Universal transaction identifier for event emission
     /// @param originCaller     Origin caller for event emission
+    /// @param recipient        Target for single-call path. Ignored for multicall/migration.
     /// @param payload          Raw payload bytes
-    function _handleExecution(bytes32 txId, bytes32 universalTxId, address originCaller, bytes calldata payload)
-        internal
-    {
+    function _handleExecution(
+        bytes32 txId,
+        bytes32 universalTxId,
+        address originCaller,
+        address recipient,
+        bytes calldata payload
+    ) internal {
         if (isMulticall(payload)) {
             Multicall[] memory calls = decodeCalls(payload);
             _handleMulticall(txId, universalTxId, originCaller, calls);
@@ -175,7 +182,7 @@ contract CEA is ICEA, ReentrancyGuard {
             _handleMigration();
             emit UniversalTxExecuted(txId, universalTxId, originCaller, address(this), payload);
         } else {
-            _handleSingleCall(txId, universalTxId, originCaller, payload);
+            _handleSingleCall(txId, universalTxId, originCaller, recipient, payload);
         }
     }
 
@@ -207,19 +214,34 @@ contract CEA is ICEA, ReentrancyGuard {
     }
 
     /// @notice         Internal handler for single call execution.
-    /// @dev            For backwards compatibility, treats payload without MULTICALL_SELECTOR
-    ///                 as direct ABI-encoded Multicall[] (old format).
-    ///                 This allows existing SDKs to continue working.
-    /// @param txId      Transaction identifier for event emission
+    /// @dev            Two modes:
+    ///                 - Empty payload: park funds (native via msg.value, ERC20 sent by Vault)
+    ///                 - Non-empty payload: execute single call to recipient
+    ///                 Self-calls (recipient == address(this)) are blocked; use multicall path instead.
+    /// @param txId             Transaction identifier for event emission
     /// @param universalTxId    Universal transaction identifier for event emission
     /// @param originCaller     Origin caller for event emission
-    /// @param payload          Raw ABI-encoded Multicall[] (old format, no selector prefix)
-    function _handleSingleCall(bytes32 txId, bytes32 universalTxId, address originCaller, bytes calldata payload)
-        internal
-    {
-        // Backwards compatibility: decode as Multicall[] directly (old format)
-        Multicall[] memory calls = abi.decode(payload, (Multicall[]));
-        _handleMulticall(txId, universalTxId, originCaller, calls);
+    /// @param recipient        Target contract for non-empty payload execution
+    /// @param payload          Raw calldata to forward to recipient (empty = park funds)
+    function _handleSingleCall(
+        bytes32 txId,
+        bytes32 universalTxId,
+        address originCaller,
+        address recipient,
+        bytes calldata payload
+    ) internal {
+        if (payload.length == 0) {
+            emit UniversalTxExecuted(txId, universalTxId, originCaller, address(this), payload);
+            return;
+        }
+
+        if (recipient == address(0)) revert CEAErrors.InvalidRecipient();
+        if (recipient == address(this)) revert CEAErrors.InvalidRecipient();
+
+        (bool success,) = recipient.call{value: msg.value}(payload);
+        if (!success) revert CEAErrors.ExecutionFailed();
+
+        emit UniversalTxExecuted(txId, universalTxId, originCaller, recipient, payload);
     }
 
     /// @notice         Internal handler for migration execution.

--- a/src/Interfaces/ICEA.sol
+++ b/src/Interfaces/ICEA.sol
@@ -72,12 +72,17 @@ interface ICEA {
      *  - CEA no longer performs automatic approval/reset logic.
      *  - This ensures flexible, composable execution paths.
      *
-     * @param txId       Transaction ID (must not be executed before)
+     * @param txId              Transaction ID (must not be executed before)
      * @param universalTxId     Unique transaction identifier on Universal Gateway
      * @param originCaller      Push account (UEA on Push Chain) that this CEA represents (verified)
+     * @param recipient         Target contract for single-call execution. Ignored for multicall/migration payloads.
      * @param payload           ABI-encoded Multicall[] containing execution steps
      */
-    function executeUniversalTx(bytes32 txId, bytes32 universalTxId, address originCaller, bytes calldata payload)
-        external
-        payable;
+    function executeUniversalTx(
+        bytes32 txId,
+        bytes32 universalTxId,
+        address originCaller,
+        address recipient,
+        bytes calldata payload
+    ) external payable;
 }

--- a/test/tests_cea/CEA.t.sol
+++ b/test/tests_cea/CEA.t.sol
@@ -179,7 +179,7 @@ contract CEATest is Test {
         // Step 3: Execute target call
         calls[2] = Multicall({to: target, value: 0, data: targetCalldata});
 
-        return abi.encode(calls);
+        return encodeCalls(calls);
     }
 
     /// @notice Build Multicall[] payload for native token operations
@@ -196,7 +196,7 @@ contract CEATest is Test {
 
         calls[0] = Multicall({to: target, value: value, data: targetCalldata});
 
-        return abi.encode(calls);
+        return encodeCalls(calls);
     }
 
     /// @notice Build Multicall[] payload for self-call (sendUniversalTxToUEA)
@@ -213,7 +213,7 @@ contract CEATest is Test {
             // Native token send or no approval needed
             Multicall[] memory calls = new Multicall[](1);
             calls[0] = Multicall({to: address(ceaInstance), value: 0, data: buildSendToUEAPayload(token, amount)});
-            return abi.encode(calls);
+            return encodeCalls(calls);
         } else {
             // ERC20 send with gateway approval
             Multicall[] memory calls = new Multicall[](3);
@@ -235,7 +235,7 @@ contract CEATest is Test {
             // Step 3: Self-call to sendUniversalTxToUEA
             calls[2] = Multicall({to: address(ceaInstance), value: 0, data: buildSendToUEAPayload(token, amount)});
 
-            return abi.encode(calls);
+            return encodeCalls(calls);
         }
     }
 
@@ -251,7 +251,7 @@ contract CEATest is Test {
     {
         Multicall[] memory calls = new Multicall[](1);
         calls[0] = Multicall({to: target, value: value, data: targetCalldata});
-        return abi.encode(calls);
+        return encodeCalls(calls);
     }
 
     // =========================================================================
@@ -362,7 +362,7 @@ contract CEATest is Test {
 
         vm.prank(nonVault);
         vm.expectRevert(Errors.NotVault.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function testExecuteUniversalTx_SuccessWhenCalledByVault() public deployCEA {
@@ -376,7 +376,7 @@ contract CEATest is Test {
         bytes memory payload = buildERC20MulticallPayload(address(token), address(spender), 100 ether, targetCalldata);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
         assertEq(spender.totalReceived(address(token)), 100 ether, "Target should receive tokens");
@@ -397,12 +397,12 @@ contract CEATest is Test {
         bytes memory payload = buildERC20MulticallPayload(address(token), address(spender), 100 ether, targetCalldata);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Try to execute same txID again
         vm.prank(vault);
         vm.expectRevert(Errors.PayloadExecuted.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // -------------------------------------------------------------------------
@@ -421,7 +421,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.InvalidUEA.selector);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(target), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, makeAddr("wrongUEA"), multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, makeAddr("wrongUEA"), address(0), multicallPayload);
     }
 
     function testExecuteUniversalTx_RevertWhenTargetIsZero() public deployCEA {
@@ -436,7 +436,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.InvalidTarget.selector);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(0), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testExecuteUniversalTx_SuccessWithSufficientTokenBalance() public deployCEA {
@@ -451,7 +451,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(spender), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(spender.totalReceived(address(token)), 100 ether, "Exact balance should work");
     }
@@ -478,7 +478,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(spender), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Approval should be reset to 0 after execution
         assertEq(token.allowance(address(ceaInstance), address(spender)), 0, "Approval should be reset");
@@ -497,7 +497,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(spender), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(spender.totalReceived(address(token)), 100 ether, "Correct amount should be approved and spent");
     }
@@ -514,7 +514,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(spender), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Approval should be reset to 0 after execution
         assertEq(token.allowance(address(ceaInstance), address(spender)), 0, "Approval should be reset after execution");
@@ -537,7 +537,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(spender), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(
             spender.totalReceived(address(token)), 100 ether, "Execution should succeed despite zero approval revert"
@@ -559,7 +559,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(target), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(target.getMagicNumber(), 42, "Target should execute correctly");
     }
@@ -577,7 +577,7 @@ contract CEATest is Test {
         bytes memory multicallPayload =
             buildERC20MulticallPayload(address(token), address(receiver), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(receiver.tokenBalances(address(token)), 100 ether, "Target should receive correct amount");
         assertEq(MockGasToken(token).balanceOf(address(receiver)), 100 ether, "Balance should be correct");
@@ -598,7 +598,7 @@ contract CEATest is Test {
 
         // Expect ExecutionFailed (revert data no longer bubbled)
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // txID should NOT be marked as executed when execution fails
         assertFalse(
@@ -623,7 +623,7 @@ contract CEATest is Test {
         bytes memory multicallPayload =
             buildERC20MulticallPayload(address(token), address(spender), 100 ether, spendPayload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(spender.totalReceived(address(token)), 100 ether, "Empty payload should work");
     }
@@ -640,7 +640,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildERC20MulticallPayload(address(token), address(target), 100 ether, payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(target.getMagicNumber(), magicValue, "Payload should execute with correct parameters");
     }
@@ -661,7 +661,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.NotVault.selector);
         bytes memory multicallPayload = buildNativeMulticallPayload(address(target), 0.1 ether, payload);
 
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testExecuteUniversalTx_RevertWhenInvalidUEA_Native() public deployCEA {
@@ -676,7 +676,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.InvalidUEA.selector);
         bytes memory multicallPayload = buildNativeMulticallPayload(address(target), 0.1 ether, payload);
 
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, makeAddr("wrongUEA"), multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, makeAddr("wrongUEA"), address(0), multicallPayload);
     }
 
     function testExecuteUniversalTx_MsgValueExceedsCallValue_Native_Succeeds() public deployCEA {
@@ -691,7 +691,7 @@ contract CEATest is Test {
         bytes memory multicallPayload = buildNativeMulticallPayload(address(target), 0.1 ether, payload);
 
         // Excess msg.value stays in CEA — no strict equality check
-        ceaInstance.executeUniversalTx{value: 0.2 ether}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0.2 ether}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(target.getMagicNumber(), 42, "Target should execute correctly");
     }
@@ -708,7 +708,7 @@ contract CEATest is Test {
         vm.deal(vault, amount);
         bytes memory multicallPayload = buildNativeMulticallPayload(address(target), amount, payload);
 
-        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(address(target).balance, amount, "Target should receive correct amount");
     }
@@ -729,7 +729,7 @@ contract CEATest is Test {
         vm.deal(vault, 0.1 ether);
         bytes memory multicallPayload = buildNativeMulticallPayload(address(target), 0.1 ether, payload);
 
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(target.getMagicNumber(), 42, "Target should execute correctly");
         assertEq(address(target).balance, 0.1 ether, "Target should receive native tokens");
@@ -748,7 +748,7 @@ contract CEATest is Test {
         vm.deal(vault, amount);
         bytes memory multicallPayload = buildNativeMulticallPayload(address(receiver), amount, payload);
 
-        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(receiver.nativeBalance(), amount, "Target should receive correct native amount");
     }
@@ -766,7 +766,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.ExecutionFailed.selector);
         bytes memory multicallPayload = buildNativeMulticallPayload(address(reverter), 0.1 ether, payload);
 
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     // =========================================================================
@@ -788,7 +788,7 @@ contract CEATest is Test {
         vm.expectEmit(true, true, true, true);
         emit ICEA.UniversalTxExecuted(txID, universalTxID, ueaOnPush, address(target), payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testExecuteUniversalTx_EmitsUniversalTxExecutedEvent_Native() public deployCEA {
@@ -806,7 +806,7 @@ contract CEATest is Test {
         vm.expectEmit(true, true, true, true);
         emit ICEA.UniversalTxExecuted(txID, universalTxID, ueaOnPush, address(target), payload);
 
-        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
     // -------------------------------------------------------------------------
     // 1. ACCESS CONTROL & AUTHORIZATION TESTS
@@ -824,7 +824,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.NotVault.selector);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_SuccessWhenCalledByVault() public deployCEA {
@@ -838,7 +838,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
@@ -859,12 +859,12 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Try to execute same txID again
         vm.prank(vault);
         vm.expectRevert(Errors.PayloadExecuted.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_RevertWhenInvalidUEA() public deployCEA {
@@ -879,7 +879,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.InvalidUEA.selector);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, makeAddr("wrongUEA"), multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, makeAddr("wrongUEA"), address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_RevertWhenPayloadTooShort() public deployCEA {
@@ -897,7 +897,7 @@ contract CEATest is Test {
         vm.prank(vault);
         // After removing _handleSelfCall, malformed calls execute via .call() and fail
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_RevertWhenInvalidSelector() public deployCEA {
@@ -922,7 +922,7 @@ contract CEATest is Test {
         // Calls initializeCEA via .call() which reverts with AlreadyInitialized
         // but we now get ExecutionFailed instead of bubbled error
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     // -------------------------------------------------------------------------
@@ -941,7 +941,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled from sendUniversalTxToUEA's InsufficientBalance
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_SuccessWithExactERC20Balance() public deployCEA {
@@ -955,7 +955,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
@@ -972,7 +972,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
     }
@@ -993,7 +993,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), amount, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(mockUniversalGateway.lastRecipient(), ueaOnPush, "Recipient should be UEA");
         assertEq(mockUniversalGateway.lastToken(), address(token), "Token should match");
@@ -1017,7 +1017,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(mockUniversalGateway.callCount(), callCountBefore + 1, "Gateway should be called exactly once");
     }
@@ -1046,7 +1046,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Approval should be set to amount (gateway may or may not consume it)
         assertEq(
@@ -1068,7 +1068,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), amount, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Gateway should have approval for exact amount
         assertEq(
@@ -1093,7 +1093,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), 500 ether, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed after");
     }
@@ -1113,7 +1113,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), sendAmount, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Gateway receives approval but mock doesn't transfer tokens
         // So balance remains the same, but approval should be granted
@@ -1145,7 +1145,7 @@ contract CEATest is Test {
 
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), amount, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_EmitsUniversalTxExecutedEvent_ERC20() public deployCEA {
@@ -1163,7 +1163,7 @@ contract CEATest is Test {
         vm.expectEmit(true, true, true, true);
         emit ICEA.UniversalTxExecuted(txID, universalTxID, ueaOnPush, address(ceaInstance), payload);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     // -------------------------------------------------------------------------
@@ -1183,7 +1183,7 @@ contract CEATest is Test {
 
         // Zero amount sends revert with ExecutionFailed (bubbled from sendUniversalTxToUEA's InvalidInput)
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_MultipleSendsWithDifferentTxIDs_ERC20() public deployCEA {
@@ -1200,7 +1200,7 @@ contract CEATest is Test {
             vm.prank(vault);
             bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), amount, true);
 
-            ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+            ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
             assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
         }
@@ -1228,7 +1228,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(token), sendAmount, true);
 
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Verify all state changes
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
@@ -1265,7 +1265,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.NotVault.selector);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_SuccessWhenCalledByVault_Native() public deployCEA {
@@ -1278,7 +1278,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
@@ -1294,12 +1294,12 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Try to execute same txID again
         vm.prank(vault);
         vm.expectRevert(Errors.PayloadExecuted.selector);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_RevertWhenInvalidUEA_Native() public deployCEA {
@@ -1313,7 +1313,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.InvalidUEA.selector);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, makeAddr("wrongUEA"), multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, makeAddr("wrongUEA"), address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_RevertWhenPayloadTooShort_Native() public deployCEA {
@@ -1330,7 +1330,7 @@ contract CEATest is Test {
         vm.prank(vault);
         // After removing _handleSelfCall, malformed calls execute via .call() and fail
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_RevertWhenInvalidSelector_Native() public deployCEA {
@@ -1354,7 +1354,7 @@ contract CEATest is Test {
         // Calls initializeCEA via .call() which reverts with AlreadyInitialized
         // but we now get ExecutionFailed instead of bubbled error
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_RevertWhenInsufficientNativeBalance() public deployCEA {
@@ -1367,7 +1367,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled from sendUniversalTxToUEA's InsufficientBalance
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_SuccessWithExactNativeBalance() public deployCEA {
@@ -1381,7 +1381,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), balance, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
@@ -1397,7 +1397,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
     }
@@ -1413,7 +1413,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), amount, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(mockUniversalGateway.lastRecipient(), ueaOnPush, "Recipient should be UEA");
         assertEq(mockUniversalGateway.lastToken(), address(0), "Token should be address(0) for native");
@@ -1435,7 +1435,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertEq(mockUniversalGateway.callCount(), callCountBefore + 1, "Gateway should be called exactly once");
     }
@@ -1452,7 +1452,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed after");
     }
@@ -1471,7 +1471,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), sendAmount, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         uint256 balanceAfter = address(ceaInstance).balance;
         assertEq(balanceAfter, balanceBefore - sendAmount, "Balance should decrease by exact amount");
@@ -1492,7 +1492,7 @@ contract CEATest is Test {
 
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), amount, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_EmitsUniversalTxExecutedEvent_Native() public deployCEA {
@@ -1509,7 +1509,7 @@ contract CEATest is Test {
         vm.expectEmit(true, true, true, true);
         emit ICEA.UniversalTxExecuted(txID, universalTxID, ueaOnPush, address(ceaInstance), payload);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_HandlesZeroAmount_Native() public deployCEA {
@@ -1524,7 +1524,7 @@ contract CEATest is Test {
 
         // Zero amount sends revert with ExecutionFailed (bubbled from sendUniversalTxToUEA's InvalidInput)
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
     }
 
     function testSendUniversalTxToUEA_MultipleSendsWithDifferentTxIDs_Native() public deployCEA {
@@ -1540,7 +1540,7 @@ contract CEATest is Test {
             vm.prank(vault);
             bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), amount, false);
 
-            ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+            ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
             assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
         }
@@ -1563,7 +1563,7 @@ contract CEATest is Test {
         vm.prank(vault);
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), sendAmount, false);
 
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), multicallPayload);
 
         // Verify all state changes
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked as executed");
@@ -1596,7 +1596,7 @@ contract CEATest is Test {
         uint256 ceaBalanceBefore = address(ceaInstance).balance;
 
         ceaInstance.executeUniversalTx{value: 1 ether}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, multicallPayload
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), multicallPayload
         );
 
         // Excess ETH stays in CEA
@@ -1618,7 +1618,7 @@ contract CEATest is Test {
 
         // Expect ExecutionFailed (revert data no longer bubbled)
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(generateTxID(1), generateUniversalTxID(1), ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), multicallPayload);
 
         // Whole tx reverts so allowance is unchanged (stays at 0)
         assertEq(
@@ -1642,7 +1642,7 @@ contract CEATest is Test {
         bytes memory multicallPayload = buildNativeMulticallPayload(address(reverter), amount, bytes(""));
 
         ceaInstance.executeUniversalTx{value: amount}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, multicallPayload
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), multicallPayload
         );
     }
 
@@ -1656,7 +1656,7 @@ contract CEATest is Test {
         vm.expectRevert(Errors.ExecutionFailed.selector);
         bytes memory multicallPayload = buildNativeMulticallPayload(address(reverter), amount, bytes(""));
 
-        ceaInstance.executeUniversalTx{value: amount}(txID, generateUniversalTxID(1), ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: amount}(txID, generateUniversalTxID(1), ueaOnPush, address(0), multicallPayload);
 
         assertFalse(
             CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should not be marked executed on failure"
@@ -1677,7 +1677,7 @@ contract CEATest is Test {
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 500 ether, false);
 
         // Note: msg.value must match total multicall values (0 in this case, as self-call doesn't need value)
-        ceaInstance.executeUniversalTx{value: 0}(generateTxID(1), generateUniversalTxID(1), ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx{value: 0}(generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), multicallPayload);
 
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
     }
@@ -1692,7 +1692,7 @@ contract CEATest is Test {
         vm.expectRevert();
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 0, false);
 
-        ceaInstance.executeUniversalTx(generateTxID(1), generateUniversalTxID(1), ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), multicallPayload);
     }
 
     function testHandleSelfCalls_RevertWhenArgsAreMalformed() public deployCEA {
@@ -1706,7 +1706,7 @@ contract CEATest is Test {
         vm.expectRevert();
         bytes memory multicallPayload = buildSendToUEAMulticallPayload(address(0), 0, false);
 
-        ceaInstance.executeUniversalTx(generateTxID(1), generateUniversalTxID(1), ueaOnPush, multicallPayload);
+        ceaInstance.executeUniversalTx(generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), multicallPayload);
     }
 
     // =========================================================================

--- a/test/tests_cea/CEA_multicalls.t.sol
+++ b/test/tests_cea/CEA_multicalls.t.sol
@@ -14,16 +14,16 @@ contract CEA_NewMulticallTests is CEATest {
     // 1) Top-level executeUniversalTx validation cases
     // =========================================================================
 
-    function test_RevertWhen_PayloadNotDecodableAsMulticall() public deployCEA {
+    function test_RevertWhen_NonEmptyPayload_ZeroRecipient() public deployCEA {
         bytes32 txID = generateTxID(1);
         bytes32 universalTxID = generateUniversalTxID(1);
 
-        // Invalid payload - not ABI-encoded Multicall[]
+        // Non-empty payload without MULTICALL_SELECTOR hits single-call path
         bytes memory invalidPayload = "not a valid multicall";
 
         vm.prank(vault);
-        vm.expectRevert(); // Will revert during abi.decode
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, invalidPayload);
+        vm.expectRevert(Errors.InvalidRecipient.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), invalidPayload);
     }
 
     function test_RevertWhen_PayloadIsEmptyCallsArray() public deployCEA {
@@ -36,7 +36,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         // Should succeed (empty multicall is valid, just does nothing)
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
     }
@@ -53,7 +53,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = buildExternalSingleCall(address(target), 0, targetCalldata);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(target.magicNumber(), 42, "Target should have magic number set");
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be executed");
@@ -70,7 +70,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = buildExternalSingleCall(address(target), value, targetCalldata);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: value}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: value}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(target.magicNumber(), 42, "Target should have magic number set");
         assertEq(address(target).balance, value, "Target should have received ETH");
@@ -88,7 +88,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = buildExternalBatch(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Final value should be 30 (last call)
         assertEq(target.magicNumber(), 30, "Target should have final magic number");
@@ -116,7 +116,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = buildExternalBatch(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(spender.totalReceived(address(token)), 100 ether, "Spender should have received tokens");
     }
@@ -136,7 +136,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_RevertWhen_LaterSubcallReverts_RollsBackEarlierEffects() public deployCEA {
@@ -155,7 +155,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // First call's effect should be rolled back
         assertEq(target.magicNumber(), magicBefore, "Target magic number should be unchanged after revert");
@@ -172,7 +172,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // txID should NOT be marked as executed since the tx reverted
         assertFalse(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should not be marked executed");
@@ -191,7 +191,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.recordLogs();
 
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertEq(logs.length, 0, "No events should be emitted on revert");
@@ -213,7 +213,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.prank(vault);
         // Now that _handleSelfCall is removed, malformed calls execute via .call() and fail
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_RevertWhen_SelfCallSelectorNotSendToUEA() public deployCEA {
@@ -234,7 +234,7 @@ contract CEA_NewMulticallTests is CEATest {
         // Calls initializeCEA via .call() which reverts with AlreadyInitialized
         // but we now get ExecutionFailed instead of bubbled error
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_SelfCallSendToUEA_ERC20_Success() public deployCEA {
@@ -260,7 +260,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
     }
@@ -280,7 +280,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled from sendUniversalTxToUEA's InsufficientBalance
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_SelfCallSendToUEA_Native_Success() public deployCEA {
@@ -296,7 +296,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
     }
@@ -315,7 +315,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled from sendUniversalTxToUEA's InsufficientBalance
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // =========================================================================
@@ -344,7 +344,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(target.magicNumber(), 99, "Final magic number should be 99");
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
@@ -366,12 +366,12 @@ contract CEA_NewMulticallTests is CEATest {
 
         // First execution succeeds
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload1);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload1);
 
         // Second execution with same txID but different payload should fail
         vm.prank(vault);
         vm.expectRevert(Errors.PayloadExecuted.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload2);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload2);
     }
 
     function test_DifferentTxID_CanExecuteSamePayload() public deployCEA {
@@ -384,11 +384,11 @@ contract CEA_NewMulticallTests is CEATest {
 
         // First execution
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID1, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID1, universalTxID, ueaOnPush, address(0), payload);
 
         // Second execution with different txID but same payload should succeed
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID2, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID2, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID1), "txID1 should be executed");
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID2), "txID2 should be executed");
@@ -411,7 +411,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.recordLogs();
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
@@ -443,7 +443,7 @@ contract CEA_NewMulticallTests is CEATest {
         // The malicious contract will try to reenter but should be blocked
         // Note: Since the malicious contract doesn't actually attempt reentry in execute(),
         // this test just verifies the call succeeds and reentrancy guard is in place
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(malicious.attackAttempted(), "Attack should have been attempted");
     }
@@ -471,7 +471,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         // msg.value (0.1) < sum of call values (0.2), but CEA has pre-existing 0.1 balance
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(target.magicNumber(), 20, "Final magic number should be 20");
     }
@@ -494,7 +494,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         // Excess ETH stays in CEA (belongs to user's UEA)
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: totalValue + excess}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: totalValue + excess}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(target.magicNumber(), 20, "Final magic number should be 20");
         assertEq(address(ceaInstance).balance, excess, "Excess ETH should remain in CEA");
@@ -518,7 +518,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: totalValue}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: totalValue}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(target.magicNumber(), 20, "Final magic number should be 20");
         assertEq(address(target).balance, totalValue, "Target should have received all ETH");
@@ -545,7 +545,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.deal(vault, 0.1 ether);
         vm.prank(vault);
         vm.expectRevert(Errors.InvalidInput.selector);
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_RevertWhen_DirectCallToSendUniversalTxToUEA() public deployCEA {
@@ -582,7 +582,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled from sendUniversalTxToUEA's InsufficientBalance
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify rollback - target should not have received ETH
         assertEq(address(target).balance, 0, "Target balance should be 0 due to rollback");
@@ -610,7 +610,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Gateway revert bubbled as ExecutionFailed
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify txID not marked executed
         assertFalse(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should not be marked");
@@ -641,7 +641,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify allowance rolled back to 0
         assertEq(token.allowance(address(ceaInstance), address(spender)), 0, "Allowance should be 0");
@@ -670,7 +670,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify gateway was NOT called (entire tx reverted before gateway interaction persisted)
         assertEq(mockUniversalGateway.callCount(), 0, "Gateway should not be called due to rollback");
@@ -692,7 +692,7 @@ contract CEA_NewMulticallTests is CEATest {
         // First attempt - should revert
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, failingPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), failingPayload);
 
         // Verify not marked executed
         assertFalse(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should not be marked");
@@ -702,7 +702,7 @@ contract CEA_NewMulticallTests is CEATest {
             buildExternalSingleCall(address(target), 0, abi.encodeWithSignature("setMagicNumber(uint256)", 42));
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, succeedingPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), succeedingPayload);
 
         // Verify now marked executed
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
@@ -724,12 +724,12 @@ contract CEA_NewMulticallTests is CEATest {
 
         // First execution with value1
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: value1}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: value1}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Try to replay with different msg.value - should still be blocked
         vm.prank(vault);
         vm.expectRevert(Errors.PayloadExecuted.selector);
-        ceaInstance.executeUniversalTx{value: value2}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: value2}(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // =========================================================================
@@ -751,7 +751,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.recordLogs();
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
@@ -802,7 +802,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.recordLogs();
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
@@ -855,7 +855,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled error no longer shown
-        ceaInstance.executeUniversalTx{value: transferAmount}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: transferAmount}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify target balance unchanged (rollback)
         assertEq(address(target).balance, targetBalanceBefore, "Target balance should not change due to rollback");
@@ -883,36 +883,10 @@ contract CEA_NewMulticallTests is CEATest {
         bytes32 universalTxID = generateUniversalTxID(1);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify execution succeeded
         assertEq(testTarget.magicNumber(), 42);
-        assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID));
-    }
-
-    function test_NoMulticallSelector_RoutesToBackwardsCompatHandler() public deployCEA {
-        MockGasToken token = new MockGasToken();
-        Target testTarget = new Target();
-        fundCEAWithTokens(address(token), 1000 ether);
-
-        // Create multicall WITHOUT MULTICALL_SELECTOR (old format)
-        Multicall[] memory calls = new Multicall[](2);
-        calls[0] = makeCall(
-            address(token), 0, abi.encodeWithSignature("approve(address,uint256)", address(testTarget), 100 ether)
-        );
-        calls[1] = makeCall(address(testTarget), 0, abi.encodeWithSignature("setMagicNumber(uint256)", 123));
-
-        // Encode without MULTICALL_SELECTOR (old way - direct abi.encode)
-        bytes memory payload = abi.encode(calls);
-
-        bytes32 txID = generateTxID(1);
-        bytes32 universalTxID = generateUniversalTxID(1);
-
-        vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
-
-        // Verify execution succeeded (backwards compatibility)
-        assertEq(testTarget.magicNumber(), 123);
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID));
     }
 
@@ -929,7 +903,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.deal(vault, 2 ether);
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 2 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 2 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(testTarget.magicNumber(), 42, "Target should have magic number set");
         assertEq(address(ceaInstance).balance, 1.9 ether, "Excess should stay in CEA");
@@ -949,7 +923,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.deal(vault, 0.1 ether);
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID));
         assertEq(testTarget.magicNumber(), 999);
@@ -969,19 +943,19 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(); // Should revert during abi.decode
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, invalidPayload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), invalidPayload);
     }
 
-    function test_PayloadLength_LessThan4Bytes_RoutesToBackwardsCompat() public deployCEA {
-        // Payload less than 4 bytes cannot have MULTICALL_SELECTOR
+    function test_PayloadLength_LessThan4Bytes_RevertsInvalidRecipient() public deployCEA {
+        // Short non-empty payload hits single-call path; recipient=address(0) reverts
         bytes memory shortPayload = bytes("abc");
 
         bytes32 txID = generateTxID(1);
         bytes32 universalTxID = generateUniversalTxID(1);
 
         vm.prank(vault);
-        vm.expectRevert(); // Should revert during abi.decode as Multicall[]
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, shortPayload);
+        vm.expectRevert(Errors.InvalidRecipient.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), shortPayload);
     }
 
     function test_MulticallSelector_EmptyCallsArray_Succeeds() public deployCEA {
@@ -992,7 +966,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes32 universalTxID = generateUniversalTxID(1);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID));
     }
@@ -1013,7 +987,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.deal(vault, 0.2 ether);
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0.2 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0.2 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID));
         assertEq(target1.magicNumber(), 300); // Last call to target1
@@ -1045,7 +1019,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.deal(vault, 0.1 ether);
         vm.prank(vault);
         vm.expectRevert(Errors.InvalidInput.selector);
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_SelfCall_WithMulticallSelector_ZeroValue_Succeeds() public deployCEA {
@@ -1068,7 +1042,7 @@ contract CEA_NewMulticallTests is CEATest {
         bytes32 universalTxID = generateUniversalTxID(1);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID));
     }
@@ -1088,7 +1062,7 @@ contract CEA_NewMulticallTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, payload
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), payload
         );
 
         assertEq(target.magicNumber(), 42, "Target should have magic number set");
@@ -1104,7 +1078,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.deal(vault, 1 ether);
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 1 ether}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, payload
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), payload
         );
 
         assertEq(target.magicNumber(), 42, "Target should have magic number set");
@@ -1125,7 +1099,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, payload
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), payload
         );
     }
 
@@ -1139,7 +1113,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, payload
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), payload
         );
     }
 
@@ -1154,7 +1128,7 @@ contract CEA_NewMulticallTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, payload
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), payload
         );
     }
 }

--- a/test/tests_cea/CEA_selfCalls.t.sol
+++ b/test/tests_cea/CEA_selfCalls.t.sol
@@ -37,7 +37,7 @@ contract CEA_ComprehensiveTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify UniversalTxRequest.recipient == UEA
         UniversalTxRequest memory lastReq = mockUniversalGateway.getLastRequest();
@@ -57,7 +57,7 @@ contract CEA_ComprehensiveTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify UniversalTxRequest.recipient == UEA
         UniversalTxRequest memory lastReq = mockUniversalGateway.getLastRequest();
@@ -83,7 +83,7 @@ contract CEA_ComprehensiveTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify revertRecipient == UEA
         UniversalTxRequest memory lastReq = mockUniversalGateway.getLastRequest();
@@ -109,7 +109,7 @@ contract CEA_ComprehensiveTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify revertRecipient == UEA (no revertMsg field anymore)
         UniversalTxRequest memory lastReq = mockUniversalGateway.getLastRequest();
@@ -143,7 +143,7 @@ contract CEA_ComprehensiveTests is CEATest {
         assertEq(balanceBefore, totalBalance, "CEA should have full balance before");
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify CEA balance is exactly 0 after sending 100%
         uint256 balanceAfter = token.balanceOf(address(ceaInstance));
@@ -170,7 +170,7 @@ contract CEA_ComprehensiveTests is CEATest {
         assertEq(balanceBefore, totalBalance, "CEA should have full balance before");
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify CEA balance is exactly 0 after sending 100%
         uint256 balanceAfter = address(ceaInstance).balance;
@@ -204,7 +204,7 @@ contract CEA_ComprehensiveTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         UniversalTxRequest memory lastReq = mockUniversalGateway.getLastRequest();
         assertEq(lastReq.amount, minAmount, "Should handle 1 wei minimum amount");
@@ -223,7 +223,7 @@ contract CEA_ComprehensiveTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         UniversalTxRequest memory lastReq = mockUniversalGateway.getLastRequest();
         assertEq(lastReq.amount, minAmount, "Should handle 1 wei minimum amount");
@@ -260,7 +260,7 @@ contract CEA_ComprehensiveTests is CEATest {
         bytes memory payload = encodeCalls(calls);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify both calls went through
         assertEq(mockUniversalGateway.callCount(), 2, "Gateway should be called twice");
@@ -297,7 +297,7 @@ contract CEA_ComprehensiveTests is CEATest {
         // After second call (send 0.4 to UEA) → CEA has 0 ETH
         vm.deal(vault, 0.1 ether);
         vm.prank(vault);
-        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 0.1 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify gateway was called with 0.4 ETH
         UniversalTxRequest memory lastReq = mockUniversalGateway.getLastRequest();
@@ -322,7 +322,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector); // Bubbled InsufficientBalance
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // =========================================================================
@@ -389,7 +389,7 @@ contract CEA_ComprehensiveTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
     }
 
@@ -407,7 +407,7 @@ contract CEA_ComprehensiveTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
     }
 
@@ -425,7 +425,7 @@ contract CEA_ComprehensiveTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
     }
 
@@ -448,7 +448,7 @@ contract CEA_ComprehensiveTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
     }
 
@@ -469,7 +469,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertTrue(mockUniversalGateway.lastCallWasViaCEA(), "Should call sendUniversalTxFromCEA for non-empty payload");
@@ -494,7 +494,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertTrue(mockUniversalGateway.lastCallWasViaCEA(), "Should call sendUniversalTxFromCEA for non-empty payload");
@@ -509,7 +509,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertTrue(mockUniversalGateway.lastCallWasViaCEA(), "Should call sendUniversalTxFromCEA for all tx types");
@@ -530,7 +530,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertTrue(mockUniversalGateway.lastCallWasViaCEA(), "Should call sendUniversalTxFromCEA for all tx types");
@@ -553,7 +553,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         UniversalTxRequest memory req = mockUniversalGateway.getLastRequest();
@@ -583,7 +583,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         UniversalTxRequest memory req = mockUniversalGateway.getLastRequest();
@@ -604,7 +604,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         UniversalTxRequest memory req = mockUniversalGateway.getLastRequest();
@@ -628,7 +628,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertEq(mockUniversalGateway.lastValue(), amount, "Native FUNDS_AND_PAYLOAD: msg.value should equal amount");
@@ -652,7 +652,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertEq(mockUniversalGateway.lastValue(), 0, "ERC20 FUNDS_AND_PAYLOAD: msg.value should be 0");
@@ -673,7 +673,7 @@ contract CEA_ComprehensiveTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.InvalidInput.selector);
         ceaInstance.executeUniversalTx{value: 1 ether}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
     }
 
@@ -699,7 +699,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertEq(mockUniversalGateway.callCount(), 1, "Gateway should be called once");
@@ -731,7 +731,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertEq(
@@ -761,7 +761,7 @@ contract CEA_ComprehensiveTests is CEATest {
         emit UniversalTxToUEA(address(ceaInstance), ueaOnPush, address(0), amount);
 
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
     }
 
@@ -786,7 +786,7 @@ contract CEA_ComprehensiveTests is CEATest {
         emit UniversalTxToUEA(address(ceaInstance), ueaOnPush, address(token), amount);
 
         ceaInstance.executeUniversalTx(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
     }
 
@@ -811,7 +811,7 @@ contract CEA_ComprehensiveTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx{value: 0}(
-            txID, generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            txID, generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertFalse(
@@ -846,7 +846,7 @@ contract CEA_ComprehensiveTests is CEATest {
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
         ceaInstance.executeUniversalTx{value: 0}(
-            generateTxID(1), generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            generateTxID(1), generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         // Magic number should NOT be set because whole multicall reverted
@@ -869,7 +869,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            txID, universalTxID, ueaOnPush, encodeCalls(calls)
+            txID, universalTxID, ueaOnPush, address(0), encodeCalls(calls)
         );
 
         // Assertions
@@ -902,7 +902,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            txID, generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            txID, generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertTrue(mockUniversalGateway.lastCallWasViaCEA(), "FUNDS-only should use sendUniversalTxFromCEA");
@@ -929,7 +929,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx{value: 0}(
-            txID, generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            txID, generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertTrue(mockUniversalGateway.lastCallWasViaCEA(), "FUNDS_AND_PAYLOAD should use sendUniversalTxFromCEA");
@@ -964,7 +964,7 @@ contract CEA_ComprehensiveTests is CEATest {
 
         vm.prank(vault);
         ceaInstance.executeUniversalTx(
-            txID, generateUniversalTxID(1), ueaOnPush, encodeCalls(calls)
+            txID, generateUniversalTxID(1), ueaOnPush, address(0), encodeCalls(calls)
         );
 
         assertTrue(mockUniversalGateway.lastCallWasViaCEA(), "FUNDS_AND_PAYLOAD should use sendUniversalTxFromCEA");

--- a/test/tests_cea/CEA_singleCall.t.sol
+++ b/test/tests_cea/CEA_singleCall.t.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "./CEA.t.sol";
+import "../../src/CEA/CEAMigration.sol";
+import {CEAProxy} from "../../src/CEA/CEAProxy.sol";
+import {MIGRATION_SELECTOR} from "../../src/libraries/Types.sol";
+
+/// @title CEA_SingleCallTests
+/// @notice Tests for CEA single-call execution path (park funds + single external call)
+contract CEA_SingleCallTests is CEATest {
+    // =========================================================================
+    // Park Funds (empty payload)
+    // =========================================================================
+
+    function test_ParkFunds_EmptyPayload_NativeViaValue() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        uint256 amount = 1 ether;
+        vm.deal(vault, amount);
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, address(0), "");
+
+        assertEq(address(ceaInstance).balance, amount, "CEA should hold parked native funds");
+        assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
+    }
+
+    function test_ParkFunds_EmptyPayload_ERC20PreFunded() public deployCEA {
+        MockGasToken token = new MockGasToken();
+        uint256 amount = 500 ether;
+        fundCEAWithTokens(address(token), amount);
+
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), "");
+
+        assertEq(token.balanceOf(address(ceaInstance)), amount, "CEA should hold ERC20 tokens");
+        assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
+    }
+
+    function test_ParkFunds_EmptyPayload_ZeroValue() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), "");
+
+        assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
+    }
+
+    function test_ParkFunds_EmptyPayload_NonZeroRecipient_Ignored() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        uint256 amount = 1 ether;
+        vm.deal(vault, amount);
+
+        address someRecipient = makeAddr("someRecipient");
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, someRecipient, "");
+
+        // Funds should park in CEA regardless of recipient value
+        assertEq(address(ceaInstance).balance, amount, "CEA should hold native funds");
+        assertEq(address(someRecipient).balance, 0, "Recipient should not receive anything");
+        assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
+    }
+
+    function test_ParkFunds_EmitsEvent_TargetIsSelf() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        vm.prank(vault);
+
+        vm.expectEmit(true, true, true, true);
+        emit ICEA.UniversalTxExecuted(txID, universalTxID, ueaOnPush, address(ceaInstance), "");
+
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), "");
+    }
+
+    // =========================================================================
+    // Single Call Execution (non-empty payload)
+    // =========================================================================
+
+    function test_SingleCall_ExecuteTargetFunction() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 42);
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(target), payload);
+
+        assertEq(target.getMagicNumber(), 42, "Target should have magic number set");
+        assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
+    }
+
+    function test_SingleCall_ForwardsMsgValueToRecipient() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        uint256 amount = 0.1 ether;
+        bytes memory payload = abi.encodeWithSignature("setMagicNumberWithFee(uint256)", 42);
+
+        vm.deal(vault, amount);
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx{value: amount}(txID, universalTxID, ueaOnPush, address(target), payload);
+
+        assertEq(target.getMagicNumber(), 42, "Target should have magic number set");
+        assertEq(address(target).balance, amount, "Target should receive native value");
+    }
+
+    function test_SingleCall_ZeroValue_ValidRecipient() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 99);
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(target), payload);
+
+        assertEq(target.getMagicNumber(), 99, "Target should have magic number set");
+    }
+
+    function test_SingleCall_EmitsEvent_CorrectTargetAndPayload() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 77);
+
+        vm.prank(vault);
+
+        vm.expectEmit(true, true, true, true);
+        emit ICEA.UniversalTxExecuted(txID, universalTxID, ueaOnPush, address(target), payload);
+
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(target), payload);
+    }
+
+    // =========================================================================
+    // Revert Cases
+    // =========================================================================
+
+    function test_SingleCall_RevertWhen_RecipientIsZero() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 42);
+
+        vm.prank(vault);
+        vm.expectRevert(Errors.InvalidRecipient.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
+    }
+
+    function test_SingleCall_RevertWhen_RecipientIsSelf() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 42);
+
+        vm.prank(vault);
+        vm.expectRevert(Errors.InvalidRecipient.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(ceaInstance), payload);
+    }
+
+    function test_SingleCall_RevertWhen_TargetReverts() public deployCEA {
+        RevertingTarget reverter = new RevertingTarget();
+
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("revertWithReason()");
+
+        vm.prank(vault);
+        vm.expectRevert(Errors.ExecutionFailed.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(reverter), payload);
+
+        assertFalse(
+            CEA(payable(address(ceaInstance))).isExecuted(txID),
+            "txID should not be marked executed on failure"
+        );
+    }
+
+    function test_SingleCall_RevertWhen_NotVault() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 42);
+
+        vm.prank(nonVault);
+        vm.expectRevert(Errors.NotVault.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(target), payload);
+    }
+
+    function test_SingleCall_RevertWhen_WrongOriginCaller() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 42);
+
+        vm.prank(vault);
+        vm.expectRevert(Errors.InvalidUEA.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, makeAddr("wrongUEA"), address(target), payload);
+    }
+
+    function test_SingleCall_RevertWhen_DuplicateTxId() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodeWithSignature("setMagicNumber(uint256)", 42);
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(target), payload);
+
+        vm.prank(vault);
+        vm.expectRevert(Errors.PayloadExecuted.selector);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(target), payload);
+    }
+
+    // =========================================================================
+    // Path Isolation
+    // =========================================================================
+
+    function test_MulticallPayload_IgnoresRecipient() public deployCEA {
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        Multicall[] memory calls = new Multicall[](1);
+        calls[0] = makeCall(address(target), 0, abi.encodeWithSignature("setMagicNumber(uint256)", 55));
+        bytes memory payload = encodeCalls(calls);
+
+        address randomRecipient = makeAddr("randomRecipient");
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, randomRecipient, payload);
+
+        assertEq(target.getMagicNumber(), 55, "Multicall should execute normally regardless of recipient");
+        assertTrue(CEA(payable(address(ceaInstance))).isExecuted(txID), "txID should be marked executed");
+    }
+
+    function test_MigrationPayload_IgnoresRecipient() public deployCEA {
+        // Set up migration contract
+        CEA ceaV2 = new CEA();
+        CEAMigration migration = new CEAMigration(address(ceaV2));
+        factory.setCEAMigrationContract(address(migration));
+
+        bytes32 txID = generateTxID(1);
+        bytes32 universalTxID = generateUniversalTxID(1);
+
+        bytes memory payload = abi.encodePacked(MIGRATION_SELECTOR);
+        address randomRecipient = makeAddr("randomRecipient");
+
+        vm.prank(vault);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, randomRecipient, payload);
+
+        assertEq(
+            CEAProxy(payable(address(ceaInstance))).getImplementation(),
+            address(ceaV2),
+            "Migration should execute normally regardless of recipient"
+        );
+    }
+}

--- a/test/tests_ceaMigration/CEAMigration_Integration.t.sol
+++ b/test/tests_ceaMigration/CEAMigration_Integration.t.sol
@@ -96,7 +96,7 @@ contract CEAMigration_IntegrationTest is Test {
         bytes memory payload = buildMigrationPayload(address(ceaInstance));
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // =========================================================================
@@ -164,7 +164,7 @@ contract CEAMigration_IntegrationTest is Test {
         bytes memory payload = abi.encodePacked(MULTICALL_SELECTOR, abi.encode(calls));
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID1, universalTxID1, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID1, universalTxID1, ueaOnPush, address(0), payload);
 
         // Verify executed
         assertTrue(ceaInstance.isExecuted(txID1), "Transaction should be marked as executed");
@@ -264,7 +264,7 @@ contract CEAMigration_IntegrationTest is Test {
         bytes memory payload = abi.encodePacked(MULTICALL_SELECTOR, abi.encode(calls));
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify executed successfully
         assertTrue(ceaInstance.isExecuted(txID), "Post-migration execution should work");
@@ -297,7 +297,7 @@ contract CEAMigration_IntegrationTest is Test {
         bytes memory payload = abi.encodePacked(MULTICALL_SELECTOR, abi.encode(calls));
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify executed successfully
         assertTrue(ceaInstance.isExecuted(txID), "Post-migration multicall should work");
@@ -314,12 +314,12 @@ contract CEAMigration_IntegrationTest is Test {
 
         // Execute migration
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Attempt to replay same migration
         vm.prank(vault);
         vm.expectRevert(Errors.PayloadExecuted.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // =========================================================================
@@ -335,7 +335,7 @@ contract CEAMigration_IntegrationTest is Test {
 
         vm.prank(nonVault);
         vm.expectRevert(Errors.NotVault.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_Migration_WrongOriginCaller() public {
@@ -347,7 +347,7 @@ contract CEAMigration_IntegrationTest is Test {
 
         vm.prank(vault);
         vm.expectRevert(Errors.InvalidUEA.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, wrongUEA, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, wrongUEA, address(0), payload);
     }
 
     // =========================================================================
@@ -374,7 +374,7 @@ contract CEAMigration_IntegrationTest is Test {
         bytes memory payload = buildMigrationPayload(address(ceaInstance));
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         assertEq(
             CEAProxy(payable(address(ceaInstance))).getImplementation(),
@@ -406,7 +406,7 @@ contract CEAMigration_IntegrationTest is Test {
             bytes memory payload = abi.encodePacked(MULTICALL_SELECTOR, abi.encode(calls));
 
             vm.prank(vault);
-            ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+            ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
         }
 
         // Verify all executed
@@ -437,7 +437,7 @@ contract CEAMigration_IntegrationTest is Test {
         bytes memory payload = buildMigrationPayload(freshCEA);
 
         vm.prank(vault);
-        freshCEAInstance.executeUniversalTx(txID, universalTxID, freshUEA, payload);
+        freshCEAInstance.executeUniversalTx(txID, universalTxID, freshUEA, address(0), payload);
 
         // Verify migration successful
         assertEq(

--- a/test/tests_ceaMigration/CEA_Migration.t.sol
+++ b/test/tests_ceaMigration/CEA_Migration.t.sol
@@ -115,7 +115,7 @@ contract CEA_MigrationTest is Test {
 
         // Execute migration (will test isMigration detection internally)
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // If execution reaches here without reverting, isMigration worked
         assertTrue(true, "Migration selector detected successfully");
@@ -136,7 +136,7 @@ contract CEA_MigrationTest is Test {
         bytes memory payload = abi.encodePacked(MIGRATION_SELECTOR);
 
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Verify implementation changed
         address implAfter = CEAProxy(payable(address(ceaInstance))).getImplementation();
@@ -154,7 +154,7 @@ contract CEA_MigrationTest is Test {
 
         vm.prank(vault);
         vm.expectRevert(Errors.InvalidInput.selector);
-        ceaInstance.executeUniversalTx{value: 1 ether}(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx{value: 1 ether}(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_handleMigration_MigrationInsideMulticall_Reverts() public {
@@ -176,7 +176,7 @@ contract CEA_MigrationTest is Test {
 
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_handleMigration_NoMigrationContract() public {
@@ -191,7 +191,7 @@ contract CEA_MigrationTest is Test {
         // Expect InvalidCall revert
         vm.prank(vault);
         vm.expectRevert(Errors.InvalidCall.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // =========================================================================
@@ -222,7 +222,7 @@ contract CEA_MigrationTest is Test {
         // Migration selector in multicall fails as generic execution failure
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     function test_handleMulticall_MigrationInBatch_FirstPosition() public {
@@ -249,7 +249,7 @@ contract CEA_MigrationTest is Test {
         // Migration selector in multicall fails as generic execution failure
         vm.prank(vault);
         vm.expectRevert(Errors.ExecutionFailed.selector);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
     }
 
     // =========================================================================
@@ -271,7 +271,7 @@ contract CEA_MigrationTest is Test {
 
         // Execute migration
         vm.prank(vault);
-        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, payload);
+        ceaInstance.executeUniversalTx(txID, universalTxID, ueaOnPush, address(0), payload);
 
         // Get updated implementation
         address implAfter = CEAProxy(payable(address(ceaInstance))).getImplementation();


### PR DESCRIPTION
### CEA Single Call Fix 
  - Updated ICEA.executeUniversalTx signature with address recipient parameter
  - Rewrote CEA._handleSingleCall — empty payload parks funds, non-empty forwards to recipient; blocks address(0) and address(this)  as recipients
  - Updated executeUniversalTx and _handleExecution to pass recipient through
  - Fixed 5 old-format test helpers (buildERC20MulticallPayload, buildNativeMulticallPayload, 

---